### PR TITLE
General command: ps --all

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ v0.2 (May 7, 2018)
 * General commands: ``write_<format> --log`` to write file contents to log
   `#2 <https://github.com/msoeken/alice/pull/2>`_
 
+* General commands: ``ps --all`` to show statistics of all store entries
+  `#5 <https://github.com/msoeken/alice/pull/5>`_
+
 v0.1 (January 11, 2018)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ v0.3 (not yet released)
 
 * Throw and catch errors in `read`.
 
+* General commands: ``ps --all`` to show statistics of all store entries
+  `#5 <https://github.com/msoeken/alice/pull/5>`_
+
 v0.2 (May 7, 2018)
 ------------------
 
@@ -16,9 +19,6 @@ v0.2 (May 7, 2018)
 
 * General commands: ``write_<format> --log`` to write file contents to log
   `#2 <https://github.com/msoeken/alice/pull/2>`_
-
-* General commands: ``ps --all`` to show statistics of all store entries
-  `#5 <https://github.com/msoeken/alice/pull/5>`_
 
 v0.1 (January 11, 2018)
 -----------------------

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -51,6 +51,20 @@ ALICE_PRINT_STORE( std::string, os, element )
   os << element << std::endl;
 }
 
+/* text printed when calling `ps -s` */
+ALICE_PRINT_STORE_STATISTICS( std::string, os, element )
+{
+  os << fmt::format( "{} characters, {} lines\n", element.size(), std::count( element.begin(), element.end(), '\n' ) );
+}
+
+ALICE_LOG_STORE_STATISTICS( std::string, element )
+{
+  return nlohmann::json{
+    {"characters", element.size()},
+    {"lines", std::count( element.begin(), element.end(), '\n' )}
+  };
+}
+
 /* HTML representation in Python (e.g., in Jupyter notebooks) */
 ALICE_STORE_HTML( std::string, element )
 {

--- a/include/alice/commands/ps.hpp
+++ b/include/alice/commands/ps.hpp
@@ -49,6 +49,7 @@ public:
     : command( env, "Print statistics" )
   {
     [](...){}( add_option_helper<S>( opts )... );
+    add_flag( "--all", "show statistics about all store entries" );
     add_flag( "--silent", "produce no output" );
   }
 
@@ -84,13 +85,25 @@ private:
 
     if ( is_set( option ) )
     {
-      if ( store<Store>().current_index() == -1 )
+      if ( is_set( "all" ) )
       {
-        env->out() << "[w] no " << name << " in store" << std::endl;
+        auto ctr{0u};
+        for ( const auto& elem : store<Store>().data() )
+        {
+          env->out() << "[i] \033[1;34m" << name << "\033[0m \033[1;33m" << ctr++ << "\033[0m\n";
+          print_statistics<Store>( env->out(), elem );
+        }
       }
       else
       {
-        print_statistics<Store>( env->out(), store<Store>().current() );
+        if ( store<Store>().current_index() == -1 )
+        {
+          env->out() << "[w] no " << name << " in store" << std::endl;
+        }
+        else
+        {
+          print_statistics<Store>( env->out(), store<Store>().current() );
+        }
       }
     }
 
@@ -109,9 +122,21 @@ private:
 
     if ( is_set( option ) )
     {
-      if ( store<Store>().current_index() != -1 )
+      if ( is_set( "all" ) )
       {
-        ret = log_statistics<Store>( store<Store>().current() );
+        auto arr = nlohmann::json::array();
+        for ( const auto& elem : store<Store>().data() )
+        {
+          arr.push_back( log_statistics<Store>( elem ) );
+        }
+        ret["all"] = arr;
+      }
+      else
+      {
+        if ( store<Store>().current_index() != -1 )
+        {
+          ret = log_statistics<Store>( store<Store>().current() );
+        }
       }
     }
 


### PR DESCRIPTION
Implements `ps --all` to show statistics on all store elements. Also works for the log.