### PR TITLE
Added persistent command history and launching standard applications under Windows

### DIFF
--- a/include/alice/commands/show.hpp
+++ b/include/alice/commands/show.hpp
@@ -153,6 +153,8 @@ private:
   std::string filename;
 #ifdef __APPLE__
   std::string program = "open {}";
+#elif _WIN32
+  std::string program = "start {}";
 #else
   std::string program = "xdg-open {}";
 #endif

--- a/include/alice/readline.hpp
+++ b/include/alice/readline.hpp
@@ -89,6 +89,17 @@ public:
   }
 
 private:
+  static constexpr const char* HISTORY = "./.history";
+  readline_wrapper()
+  {
+    read_history(HISTORY);
+  }
+
+  ~readline_wrapper()
+  {
+    write_history(HISTORY);
+  }
+
   static char** readline_completion_s( const char* text, int start, int end )
   {
     (void)end;


### PR DESCRIPTION
All commands used will be saved in a file called "./.history" when the CLI is closed and from there be read when it is started the next time. This enables a persistent history.

Additionally, "start" is used under Windows to launch standard applications as "xdg-open" is not available.