### PR TITLE
Updated pybind11 to version 2.5.0 and fixed a compiler warning

### DIFF
--- a/include/alice/commands/convert.hpp
+++ b/include/alice/commands/convert.hpp
@@ -52,14 +52,14 @@ int add_combination_helper_inner( CLI::App& opts )
                    fmt::format( "convert {} to {}", source_name, dest_name ) );
   }
   return 0;
-};
+}
 
 template<typename D, class... S>
 int add_combination_helper( CLI::App& opts )
 {
   []( ... ) {}( add_combination_helper_inner<D, S>( opts )... );
   return 0;
-};
+}
 
 template<typename D, class S>
 int convert_helper_inner( const environment::ptr& env, const command& cmd )

--- a/include/alice/commands/show.hpp
+++ b/include/alice/commands/show.hpp
@@ -153,6 +153,8 @@ private:
   std::string filename;
 #ifdef __APPLE__
   std::string program = "open {}";
+#elif _WIN32
+  std::string program = "start {}";
 #else
   std::string program = "xdg-open {}";
 #endif

--- a/include/alice/readline.hpp
+++ b/include/alice/readline.hpp
@@ -89,6 +89,17 @@ public:
   }
 
 private:
+  static constexpr const char* HISTORY = "./.history";
+  readline_wrapper()
+  {
+    read_history(HISTORY);
+  }
+
+  ~readline_wrapper()
+  {
+    write_history(HISTORY);
+  }
+
   static char** readline_completion_s( const char* text, int start, int end )
   {
     (void)end;


### PR DESCRIPTION
This PR updates pybind11 to the latest stable version 2.5.0. Furthermore, it fixes a compiler warning that complained about an additional semicolon.